### PR TITLE
Bugfix: client returning 500 internal server error when retrieving posts for dashboard

### DIFF
--- a/src/controllers/post.js
+++ b/src/controllers/post.js
@@ -42,7 +42,7 @@ export const getAll = async (req, res) => {
                 lastName: true,
                 bio: true,
                 githubUrl: true,
-                profileimageUrl: true
+                profilePicture: true
               }
             }
           }

--- a/src/controllers/post.js
+++ b/src/controllers/post.js
@@ -36,11 +36,15 @@ export const getAll = async (req, res) => {
             id: true,
             cohortId: true,
             role: true,
-            firstName: true,
-            lastName: true,
-            bio: true,
-            githubUrl: true,
-            profileimageUrl: true
+            profile: {
+              select: {
+                firstName: true,
+                lastName: true,
+                bio: true,
+                githubUrl: true,
+                profileimageUrl: true
+              }
+            }
           }
         }
       }

--- a/src/controllers/post.js
+++ b/src/controllers/post.js
@@ -17,7 +17,7 @@ export const create = async (req, res) => {
       }
     })
 
-    return sendDataResponse(res, 201, { post: { id: post.id, content } })
+    return sendDataResponse(res, 201, { posts: { id: post.id, content } })
   } catch (e) {
     return res.status(401).json({ error: 'Not authorised' })
   }
@@ -49,7 +49,7 @@ export const getAll = async (req, res) => {
         }
       }
     })
-    return sendDataResponse(res, 200, { posts })
+    return sendDataResponse(res, 200, { posts: posts })
   } catch (e) {
     return sendMessageResponse(res, 500, 'Unable to fetch')
   }


### PR DESCRIPTION
Problem is actually due to code for rendering posts from API not complete yet, but pushing this anyway as the changes should be needed when it is live. Only changes are reformatting how 'posts' is returned in controllers/post.js getAll and changing 'post' to 'posts' in response string.